### PR TITLE
修复Bug  proxy代理的url并没有先对query进行url序列化

### DIFF
--- a/middleware/proxy/index.js
+++ b/middleware/proxy/index.js
@@ -269,7 +269,13 @@ module.exports = function proxy(app, api, config, options) {
     query = query || {};
     // 把页面url中的请求参数和数据连接中的请求参数合并
     urlQue = Object.assign({}, query, urlQue);
-
+    // 将query urlComponent编码化
+    Object.keys(urlQue).map(function(wd){
+      urlQue[encodeURIComponent(wd)] = encodeURIComponent(urlQue[wd]);
+      if(encodeURIComponent(wd) != wd){
+          delete urlQue[wd]
+      }
+    });
     // 把合并之后参数进行stringify，作为新的参数
     let queStr = querystring.stringify(urlQue);
     let urlStr = urlObj.protocol + '//' + urlObj.host + urlObj.pathname;


### PR DESCRIPTION
在具体业务中，service-api:/mobile/v1/submit?uid=123&time=1993-2-3 10:00─11:00
无法正确识别符号  ─  导致proxy的url解析出现问题   无法发出Request请求
目前在业务中对每个query进行了 encodeURLComponent()  在拼接发送